### PR TITLE
perf(*): containerized dccmonitor_ECS

### DIFF
--- a/.github/workflows/Release_Docker_build.yml
+++ b/.github/workflows/Release_Docker_build.yml
@@ -1,7 +1,7 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/master/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 
-name: Create and publish a Docker image
+name: Create Github release and generate Docker image
 
 on:
   push:
@@ -33,6 +33,7 @@ jobs:
           body: ${{ steps.tag_version.outputs.changelog }}  
 
   build-and-push-image:
+    needs: tagging
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -55,6 +56,7 @@ jobs:
         uses: docker/metadata-action@v4.1.1
         with:
           images: ${{ env.IMAGE_PATH }}
+          tags: ${{ needs.tagging.outputs.tag}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v3.2.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,6 @@ COPY --chown=shiny ./ ./
 RUN Rscript -e "install.packages('reticulate', repos='http://cran.rstudio.com/', verbose=FALSE)"
 RUN Rscript -e "library(reticulate); install_miniconda(); py_discover_config(); py_install(c('synapseclient', 'pandas'), pip = TRUE, pip_ignore_installed=TRUE)"
 
-# alternative to using renv
-#RUN Rscript -e "install.packages(c('shinydashboard','tidyverse','readxl','gt','gtsummary','survival','survminer','rsconnect','janitor','rjson'), repos='http://cran.rstudio.com/', verbose=FALSE)"
-
 # By default the log level is TRACE.  We bump up one level to DEBUG to make the logs a bit less verbose
 ENV SHINY_LOG_LEVEL=DEBUG
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -7,24 +7,16 @@ app_url <- NULL
 claims_param <- NULL
 authorization_url <- NULL
 
-if (interactive()) {
-  # testing url
-  options(shiny.port = 8100)
-  app_url <- "http://127.0.0.1:8100"
-} else {
-  app_url <- Sys.getenv("APP_REDIRECT_URL")
-}
-
 .onLoad <- function(libname, pkgname) { # nolint
   synapse <<- reticulate::import("synapseclient", delay_load = TRUE)
-  if (!interactive()) {
+  #if (!interactive()) {
     setup_global_oauth_vars(
-      app_url = Sys.getenv("app_url"),
+      app_url = Sys.getenv("APP_REDIRECT_URL"),
       client_name = Sys.getenv("client_name"),
       client_id = Sys.getenv("client_id"),
       client_secret = Sys.getenv("client_secret")
     )
-  }
+  #}
 }
 
 #' @title Synapse Oauth Module

--- a/app.R
+++ b/app.R
@@ -1,7 +1,6 @@
 # Launch the ShinyApp (Do not remove this comment)
 # To deploy, run: rsconnect::deployApp()
 # Or use the blue button on top of this file
-
 Sys.setenv(R_CONFIG_ACTIVE = Sys.getenv("R_CONFIG_ACTIVE"), # Replace "default" with your config
            R_CONFIG_FILE = "inst/config.yml")
 pkgload::load_all()

--- a/dccmonitor_startup.sh
+++ b/dccmonitor_startup.sh
@@ -3,6 +3,9 @@
 # Pass environment variable to Shiny
 echo "" >> .Renviron
 echo APP_REDIRECT_URL=$APP_REDIRECT_URL >> .Renviron
-
+echo R_CONFIG_ACTIVE=$R_CONFIG_ACTIVE >> .Renviron
+echo client_id=$client_id >> .Renviron
+echo client_name=$client_name >> .Renviron
+echo client_secret=$client_secret >> .Renviron
 # Now run the base start-up script
 ./startup.sh

--- a/inst/config.yml
+++ b/inst/config.yml
@@ -110,7 +110,6 @@ amp-ad:
       - "specimenID"
 
 pec:
-  #app_url: "https://shinypro.synapse.org/users/danlu/dccmonitor-pec/"
   samples_table: "syn22175287"
   annotations_table: "syn20981788"
   annotations_storage: "syn21763155"
@@ -176,7 +175,6 @@ pec:
       - "runType"
 
 1kD:
-  #app_url: "https://shinypro.synapse.org/users/danlu/dccmonitor_1kD/"
   samples_table: "syn27817789"
   annotations_table: "syn27806892"
   annotations_storage: "syn27605404"


### PR DESCRIPTION
perf(*):update GitHub workflow to use a tag when creating a docker image and allow configuration values to be passed as the environment variable

BREAKING CHANGE: The dccmonitor_startup.sh has been changed to allow Oauth client information to be passed to .Renviron file. The zzz.R has been changed to accept environment variable for Oauth client values all the time. 
